### PR TITLE
feat: add failOnError optional configuration parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,9 @@ repositories {
 
 dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0'
+
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation("org.assertj:assertj-core:3.27.3")
     testImplementation "org.junit.jupiter:junit-jupiter:5.9.2"
     testImplementation "org.wiremock:wiremock:3.12.1"
     testImplementation(gradleTestKit())

--- a/src/main/kotlin/com/guidewire/plugin/FernPublisherExtension.kt
+++ b/src/main/kotlin/com/guidewire/plugin/FernPublisherExtension.kt
@@ -10,9 +10,11 @@ abstract class FernPublisherExtension {
   abstract val reportPaths: ListProperty<String>
   abstract val fernTags: ListProperty<String>
   abstract val verbose: Property<Boolean>
+  abstract val failOnError: Property<Boolean>
 
   init {
     fernTags.convention(listOf())
     verbose.convention(false)
+    failOnError.convention(false)
   }
 }

--- a/src/main/kotlin/com/guidewire/plugin/FernPublisherPlugin.kt
+++ b/src/main/kotlin/com/guidewire/plugin/FernPublisherPlugin.kt
@@ -17,6 +17,7 @@ class FernPublisherPlugin : Plugin<Project> {
       extension.reportPaths.orNull?.let { task.reportPaths.set(it) }
       extension.fernTags.orNull?.let { task.fernTags.set(it) }
       extension.verbose.orNull?.let { task.verbose.set(it) }
+      extension.failOnError.orNull?.let {task.failOnError.set(it) }
       task.projectDir.set(project.projectDir.absolutePath + "/")
     }
   }

--- a/src/main/kotlin/com/guidewire/plugin/PublishToFern.kt
+++ b/src/main/kotlin/com/guidewire/plugin/PublishToFern.kt
@@ -33,10 +33,15 @@ abstract class PublishToFern : DefaultTask() {
   @get:Internal
   abstract val projectDir: Property<String>
 
+  @get:Input
+  @get:Optional
+  abstract val failOnError: Property<Boolean>
+
   init {
     fernTags.convention(listOf()) // Set default value
     verbose.convention(false)
     description = "Publish test results to your Fern instance"
+    failOnError.convention(false)
   }
 
   @TaskAction
@@ -52,6 +57,10 @@ abstract class PublishToFern : DefaultTask() {
 
     if (reportPaths.get().isEmpty()) {
       logger.error("No report paths provided. Cannot publish results.")
+      if(failOnError.get()) {
+        throw RuntimeException("No report paths provided. Cannot publish results.")
+      }
+
       return
     }
 
@@ -80,7 +89,10 @@ abstract class PublishToFern : DefaultTask() {
           if (isVerbose) {
             logger.error("Stack trace: ", error)
           }
-          throw error
+
+          if(failOnError.get()) {
+            throw error
+          }
         }
       )
     }
@@ -102,7 +114,10 @@ abstract class PublishToFern : DefaultTask() {
         if (isVerbose) {
           logger.error("Stack trace: ", error)
         }
-        throw RuntimeException("Failed to publish test results to Fern", error)
+
+        if(failOnError.get()) {
+          throw RuntimeException("Failed to publish test results to Fern", error)
+        }
       }
     )
   }

--- a/src/test/kotlin/FernPublisherPluginTest.kt
+++ b/src/test/kotlin/FernPublisherPluginTest.kt
@@ -3,13 +3,13 @@ import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.guidewire.plugin.FernPublisherExtension
 import com.guidewire.plugin.PublishToFern
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -18,32 +18,32 @@ import java.nio.file.Path
 
 class FernPublisherPluginTest {
 
-  @TempDir
-  lateinit var projectDir: Path
+    @TempDir
+    lateinit var projectDir: Path
 
-  private lateinit var buildFile: File
-  private lateinit var testReportDir: File
-  private lateinit var wireMockServer: WireMockServer
+    private lateinit var buildFile: File
+    private lateinit var testReportDir: File
+    private lateinit var wireMockServer: WireMockServer
 
-  @BeforeEach
-  fun setup() {
-    buildFile = projectDir.resolve("build.gradle.kts").toFile()
-    testReportDir = projectDir.resolve("build/test-results/test").toFile()
-    testReportDir.mkdirs()
+    @BeforeEach
+    fun setup() {
+        buildFile = projectDir.resolve("build.gradle.kts").toFile()
+        testReportDir = projectDir.resolve("build/test-results/test").toFile()
+        testReportDir.mkdirs()
 
-    // Start mock server
-    wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
-    wireMockServer.start()
-    configureFor("localhost", wireMockServer.port())
+        // Start mock server
+        wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
+        wireMockServer.start()
+        configureFor("localhost", wireMockServer.port())
 
-    // Stub the API endpoint
-    stubFor(
-      post(urlEqualTo("/api/testrun/"))
-        .willReturn(aResponse().withStatus(200))
-    )
+        // Stub the API endpoint
+        stubFor(
+            post(urlEqualTo("/api/testrun/"))
+                .willReturn(aResponse().withStatus(200))
+        )
 
-    // Create sample test report
-    val sampleXml = """
+        // Create sample test report
+        val sampleXml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <testsuite name="SampleTest" tests="2" failures="0" errors="0" skipped="0" time="1.234">
                 <testcase name="testOne" time="0.5"/>
@@ -51,44 +51,44 @@ class FernPublisherPluginTest {
             </testsuite>
         """.trimIndent()
 
-    val reportFile = testReportDir.resolve("TEST-SampleTest.xml")
-    Files.write(reportFile.toPath(), sampleXml.toByteArray())
-  }
-
-  @AfterEach
-  fun tearDown() {
-    wireMockServer.stop()
-  }
-
-  @Test
-  fun `plugin should apply correctly to project`() {
-    val project = ProjectBuilder.builder().build()
-    project.plugins.apply("com.guidewire.fern-publisher")
-
-    assertTrue(project.tasks.findByName("publishToFern") is PublishToFern)
-  }
-
-  @Test
-  fun `plugin extension should configure task properties`() {
-    val project = ProjectBuilder.builder().build()
-    project.plugins.apply("com.guidewire.fern-publisher")
-
-    project.extensions.configure<FernPublisherExtension>("fernPublisher") {
-      it.fernUrl.set("http://example.com")
-      it.projectName.set("test-project")
-      it.reportPaths.set(listOf("build/reports/**/*.xml"))
+        val reportFile = testReportDir.resolve("TEST-SampleTest.xml")
+        Files.write(reportFile.toPath(), sampleXml.toByteArray())
     }
 
-    val task = project.tasks.findByName("publishToFern") as PublishToFern
-    assertEquals("http://example.com", task.fernUrl.get())
-    assertEquals("test-project", task.projectName.get())
-    assertEquals(listOf("build/reports/**/*.xml"), task.reportPaths.get())
-  }
+    @AfterEach
+    fun tearDown() {
+        wireMockServer.stop()
+    }
 
-  @Test
-  fun `task should successfully publish test results`() {
-    buildFile.writeText(
-      """
+    @Test
+    fun `plugin should apply correctly to project`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.guidewire.fern-publisher")
+
+        assertTrue(project.tasks.findByName("publishToFern") is PublishToFern)
+    }
+
+    @Test
+    fun `plugin extension should configure task properties`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.guidewire.fern-publisher")
+
+        project.extensions.configure<FernPublisherExtension>("fernPublisher") {
+            it.fernUrl.set("http://example.com")
+            it.projectName.set("test-project")
+            it.reportPaths.set(listOf("build/reports/**/*.xml"))
+        }
+
+        val task = project.tasks.findByName("publishToFern") as PublishToFern
+        assertEquals("http://example.com", task.fernUrl.get())
+        assertEquals("test-project", task.projectName.get())
+        assertEquals(listOf("build/reports/**/*.xml"), task.reportPaths.get())
+    }
+
+    @Test
+    fun `task should successfully publish test results`() {
+        buildFile.writeText(
+            """
             plugins {
                 id("com.guidewire.fern-publisher")
             }
@@ -100,36 +100,36 @@ class FernPublisherPluginTest {
                 verbose.set(true)
             }
         """.trimIndent()
-    )
+        )
 
-    val result = GradleRunner.create()
-      .withProjectDir(projectDir.toFile())
-      .withPluginClasspath()
-      .withArguments("publishToFern", "--stacktrace")
-      .build()
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withPluginClasspath()
+            .withArguments("publishToFern", "--stacktrace")
+            .build()
 
-    // Verify task execution
-    assertTrue(result.output.contains("Executing PublishToFern"))
-    assertTrue(result.output.contains("Successfully published test results to Fern"))
+        // Verify task execution
+        assertTrue(result.output.contains("Executing PublishToFern"))
+        assertTrue(result.output.contains("Successfully published test results to Fern"))
 
-    // Verify the API was called
-    verify(
-      postRequestedFor(urlEqualTo("/api/testrun/"))
-        .withHeader("Content-Type", equalTo("application/json"))
-    )
-  }
+        // Verify the API was called
+        verify(
+            postRequestedFor(urlEqualTo("/api/testrun/"))
+                .withHeader("Content-Type", equalTo("application/json"))
+        )
+    }
 
-  @Test
-  fun `task should handle API errors`() {
-    // Reset stub to return an error
-    reset()
-    stubFor(
-      post(urlEqualTo("/api/testrun/"))
-        .willReturn(aResponse().withStatus(500))
-    )
+    @Test
+    fun `task should handle API errors`() {
+        // Reset stub to return an error
+        reset()
+        stubFor(
+            post(urlEqualTo("/api/testrun/"))
+                .willReturn(aResponse().withStatus(500))
+        )
 
-    buildFile.writeText(
-      """
+        buildFile.writeText(
+            """
             plugins {
                 id("com.guidewire.fern-publisher")
             }
@@ -138,24 +138,25 @@ class FernPublisherPluginTest {
                 fernUrl.set("http://localhost:${wireMockServer.port()}")
                 projectName.set("test-project")
                 reportPaths.set(listOf("build/test-results/test/**/*.xml"))
+                failOnError.set(true)
             }
         """.trimIndent()
-    )
+        )
 
-    val runner = GradleRunner.create()
-      .withProjectDir(projectDir.toFile())
-      .withPluginClasspath()
-      .withArguments("publishToFern")
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withPluginClasspath()
+            .withArguments("publishToFern")
 
-    val result = runner.buildAndFail()
+        val result = runner.buildAndFail()
 
-    assertTrue(result.output.contains("Failed to publish test results to Fern"))
-  }
+        assertTrue(result.output.contains("Failed to publish test results to Fern"))
+    }
 
-  @Test
-  fun `task should handle missing report files`() {
-    buildFile.writeText(
-      """
+    @Test
+    fun `task should handle missing report files`() {
+        buildFile.writeText(
+            """
             plugins {
                 id("com.guidewire.fern-publisher")
             }
@@ -164,17 +165,73 @@ class FernPublisherPluginTest {
                 fernUrl.set("http://localhost:${wireMockServer.port()}")
                 projectName.set("test-project")
                 reportPaths.set(listOf("non-existent/**/*.xml"))
+                failOnError.set(true)
             }
         """.trimIndent()
-    )
+        )
 
-    val runner = GradleRunner.create()
-      .withProjectDir(projectDir.toFile())
-      .withPluginClasspath()
-      .withArguments("publishToFern")
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withPluginClasspath()
+            .withArguments("publishToFern")
 
-    val result = runner.buildAndFail()
+        val result = runner.buildAndFail()
 
-    assertTrue(result.output.contains("No files found"))
-  }
+        assertTrue(result.output.contains("No files found"))
+    }
+
+    @Test
+    fun `task should fail when failOnError is true`() {
+        buildFile.writeText(
+            """
+            plugins {
+                id("com.guidewire.fern-publisher")
+            }
+            
+            fernPublisher {
+                fernUrl.set("http://localhost:${wireMockServer.port()}")
+                projectName.set("test-project")
+                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
+                verbose.set(true)
+                failOnError.set(true)
+            }
+        """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withPluginClasspath()
+            .withArguments("publishToFern", "--stacktrace")
+            .buildAndFail()
+
+        // Verify task execution
+        assertThat(result.output).contains("Failed to parse reports")
+    }
+
+    @Test
+    fun `task should NOT fail when failOnError is false but still log errors`() {
+        buildFile.writeText(
+            """
+            plugins {
+                id("com.guidewire.fern-publisher")
+            }
+            
+            fernPublisher {
+                fernUrl.set("http://localhost:${wireMockServer.port()}")
+                projectName.set("test-project")
+                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
+                verbose.set(true)
+            }
+        """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withPluginClasspath()
+            .withArguments("publishToFern", "--stacktrace")
+            .build()
+
+        // Verify task execution
+        assertThat(result.output).contains("Failed to parse reports")
+    }
 }


### PR DESCRIPTION
Closes https://github.com/guidewire-oss/fern-junit-gradle-plugin/issues/2

* adds optional `failOnError` configuration parameter
  * defaults to `false`
  * when `true`, fails the publishToFern task
  * when `false`, task is successful but logs are still printed for debugging purposes