### PR TITLE
Fix: Make file globbing much more flexible

### DIFF
--- a/src/test/kotlin/TestParserTest.kt
+++ b/src/test/kotlin/TestParserTest.kt
@@ -2,6 +2,7 @@ import com.guidewire.models.TestRun
 import com.guidewire.parseReports
 import com.guidewire.util.GlobalClock
 import com.guidewire.util.MockClock
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -13,8 +14,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import kotlin.io.path.absolutePathString
-
-//TODO make tests better
+import kotlin.io.path.createDirectory
 
 class TestParserTest {
   @TempDir
@@ -39,6 +39,187 @@ class TestParserTest {
   }
 
   @Test
+  fun `parseReports should correctly parse a single hardcoded file path`() {
+    // Create test XML file
+    val xmlContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test One" time="0.5"/>
+                <testcase name="Test Two" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    val testFile = tempDir.resolve("test-report.xml")
+    Files.write(testFile, xmlContent.toByteArray())
+
+    // Parse the report
+    val result = parseReports(testRun = testRun, filePattern = testFile.parent.toString() + "/test-report.xml", tags = "tag1,tag2", verbose = true)
+    println(result.exceptionOrNull()?.printStackTrace())
+
+    assertThat(result.isSuccess).isTrue()
+    assertThat(testRun.suiteRuns).hasSize(1)
+    assertThat(testRun.suiteRuns[0].suiteName).isEqualTo("Sample Test Suite")
+    assertThat(testRun.suiteRuns[0].specRuns).hasSize(2)
+    assertThat(testRun.suiteRuns[0].specRuns[0].specDescription).isEqualTo("Test One")
+    assertThat(testRun.suiteRuns[0].specRuns[0].status).isEqualTo("passed")
+    assertThat(testRun.suiteRuns[0].specRuns[0].tags).hasSize(2)
+    assertThat(testRun.suiteRuns[0].specRuns[0].tags[0].name).isEqualTo("tag1")
+    assertThat(testRun.suiteRuns[0].specRuns[0].tags[1].name).isEqualTo("tag2")
+  }
+
+  @Test
+  fun `parseReports should correctly parse file a wildcard file path`() {
+    // Create 2 test XML files
+    val xmlContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test One" time="0.5"/>
+                <testcase name="Test Two" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    val testFile = tempDir.resolve("test-report.xml")
+    Files.write(testFile, xmlContent.toByteArray())
+
+    val xmlContent2 = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Extra Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test Three" time="0.5"/>
+                <testcase name="Test Four" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    val testFile2 = tempDir.resolve("test-report2.xml")
+    Files.write(testFile2, xmlContent2.toByteArray())
+
+    // Parse the report
+    val result = parseReports(testRun = testRun, filePattern = testFile.parent.toString() + "/*.xml", tags = "tag1,tag2", verbose = true)
+    println(result.exceptionOrNull()?.printStackTrace())
+
+    // parsed all files
+    assertThat(result.isSuccess).isTrue()
+    assertThat(testRun.suiteRuns.size).isEqualTo(2)
+
+    //parsed all suites
+    val suitNames = testRun.suiteRuns.map { it.suiteName }.toSet()
+    assertThat(suitNames).containsAll(listOf("Extra Sample Test Suite", "Sample Test Suite"))
+
+    //parsed all runs
+    val specDescriptions = testRun.suiteRuns.flatMap { suiteRun ->
+      suiteRun.specRuns.map {
+        it.specDescription
+      }
+    }.toSet()
+
+    assertThat(specDescriptions.size).isEqualTo(4)
+    assertThat(specDescriptions).containsAll(listOf("Test One", "Test Two", "Test Three", "Test Four"))
+  }
+
+  @Test
+  fun `parseReports should correctly parse file double wildcard file path`() {
+    // Create 2 test XML files
+    val xmlContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test One" time="0.5"/>
+                <testcase name="Test Two" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    val testFile = tempDir.resolve("test-report.xml")
+    Files.write(testFile, xmlContent.toByteArray())
+
+    val xmlContent2 = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Extra Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test Three" time="0.5"/>
+                <testcase name="Test Four" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    val testFile2 = tempDir.resolve("test-report2.xml")
+    Files.write(testFile2, xmlContent2.toByteArray())
+
+    // Parse the report
+    val result = parseReports(testRun = testRun, filePattern = testFile.parent.toString() + "/**/*.xml", tags = "tag1,tag2", verbose = true)
+    println(result.exceptionOrNull()?.printStackTrace())
+
+    // parsed all files
+    assertThat(result.isSuccess).isTrue()
+    assertThat(testRun.suiteRuns.size).isEqualTo(2)
+
+    //parsed all suites
+    val suitNames = testRun.suiteRuns.map { it.suiteName }.toSet()
+    assertThat(suitNames).containsAll(listOf("Extra Sample Test Suite", "Sample Test Suite"))
+
+    //parsed all runs
+    val specDescriptions = testRun.suiteRuns.flatMap { suiteRun ->
+      suiteRun.specRuns.map {
+        it.specDescription
+      }
+    }.toSet()
+
+    assertThat(specDescriptions.size).isEqualTo(4)
+    assertThat(specDescriptions).containsAll(listOf("Test One", "Test Two", "Test Three", "Test Four"))
+  }
+
+  @Test
+  fun `parseReports should correctly parse files in multiple sub directories`() {
+    // Create 2 test XML files
+    val xmlContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test One" time="0.5"/>
+                <testcase name="Test Two" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    val testFile = tempDir.resolve("test-report.xml")
+    Files.write(testFile, xmlContent.toByteArray())
+
+    val xmlContent2 = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="Extra Sample Test Suite" tests="2" failures="0" errors="0" skipped="0" 
+                       timestamp="2023-01-01T09:00:00Z" time="1.5">
+                <testcase name="Test Three" time="0.5"/>
+                <testcase name="Test Four" time="1.0"/>
+            </testsuite>
+        """.trimIndent()
+
+    Files.createDirectory(tempDir.resolve("extra"))
+    val testFile2 = tempDir.resolve("extra/test-report2.xml")
+    Files.write(testFile2, xmlContent2.toByteArray())
+
+    // Parse the report
+    val result = parseReports(testRun = testRun, filePattern = testFile.parent.toString() + "/**/*.xml", tags = "tag1,tag2", verbose = true)
+    println(result.exceptionOrNull()?.printStackTrace())
+
+    // parsed all files
+    assertThat(result.isSuccess).isTrue()
+    assertThat(testRun.suiteRuns.size).isEqualTo(2)
+
+    //parsed all suites
+    val suitNames = testRun.suiteRuns.map { it.suiteName }.toSet()
+    assertThat(suitNames).containsAll(listOf("Extra Sample Test Suite", "Sample Test Suite"))
+
+    //parsed all runs
+    val specDescriptions = testRun.suiteRuns.flatMap { suiteRun ->
+      suiteRun.specRuns.map {
+        it.specDescription
+      }
+    }.toSet()
+
+    assertThat(specDescriptions.size).isEqualTo(4)
+    assertThat(specDescriptions).containsAll(listOf("Test One", "Test Two", "Test Three", "Test Four"))
+  }
+
+  @Test
   fun `parseReports should correctly parse valid XML reports`() {
     // Create test XML file
     val xmlContent = """
@@ -58,15 +239,15 @@ class TestParserTest {
 
     println(result.exceptionOrNull()?.printStackTrace())
 
-    assertTrue(result.isSuccess)
-    assertEquals(1, testRun.suiteRuns.size)
-    assertEquals("Sample Test Suite", testRun.suiteRuns[0].suiteName)
-    assertEquals(2, testRun.suiteRuns[0].specRuns.size)
-    assertEquals("Test One", testRun.suiteRuns[0].specRuns[0].specDescription)
-    assertEquals("passed", testRun.suiteRuns[0].specRuns[0].status)
-    assertEquals(2, testRun.suiteRuns[0].specRuns[0].tags.size)
-    assertEquals("tag1", testRun.suiteRuns[0].specRuns[0].tags[0].name)
-    assertEquals("tag2", testRun.suiteRuns[0].specRuns[0].tags[1].name)
+    assertThat(result.isSuccess).isTrue()
+    assertThat(testRun.suiteRuns).hasSize(1)
+    assertThat(testRun.suiteRuns[0].suiteName).isEqualTo("Sample Test Suite")
+    assertThat(testRun.suiteRuns[0].specRuns).hasSize(2)
+    assertThat(testRun.suiteRuns[0].specRuns[0].specDescription).isEqualTo("Test One")
+    assertThat(testRun.suiteRuns[0].specRuns[0].status).isEqualTo("passed")
+    assertThat(testRun.suiteRuns[0].specRuns[0].tags).hasSize(2)
+    assertThat(testRun.suiteRuns[0].specRuns[0].tags[0].name).isEqualTo("tag1")
+    assertThat(testRun.suiteRuns[0].specRuns[0].tags[1].name).isEqualTo("tag2")
   }
 
   @Test
@@ -88,12 +269,12 @@ class TestParserTest {
 
     println(result.exceptionOrNull()?.printStackTrace())
 
-    assertTrue(result.isSuccess)
-    assertEquals(1, testRun.suiteRuns.size)
-    assertEquals(2, testRun.suiteRuns[0].specRuns.size)
-    assertEquals("passed", testRun.suiteRuns[0].specRuns[0].status)
-    assertEquals("failed", testRun.suiteRuns[0].specRuns[1].status)
-    assertTrue(testRun.suiteRuns[0].specRuns[1].message.contains("Assertion failed"))
+    assertThat(result.isSuccess).isTrue();
+    assertThat(testRun.suiteRuns).hasSize(1);
+    assertThat(testRun.suiteRuns[0].specRuns).hasSize(2);
+    assertThat(testRun.suiteRuns[0].specRuns[0].status).isEqualTo("passed");
+    assertThat(testRun.suiteRuns[0].specRuns[1].status).isEqualTo("failed");
+    assertThat(testRun.suiteRuns[0].specRuns[1].message).contains("Assertion failed");
   }
 
   @Test
@@ -113,9 +294,9 @@ class TestParserTest {
 
     val result = parseReports(testRun = testRun, filePattern = testFile.toString(), verbose = true)
 
-    assertTrue(result.isSuccess)
-    assertEquals("passed", testRun.suiteRuns[0].specRuns[0].status)
-    assertEquals("skipped", testRun.suiteRuns[0].specRuns[1].status)
+    assertThat(result.isSuccess).isTrue()
+    assertThat(testRun.suiteRuns[0].specRuns[0].status).isEqualTo("passed");
+    assertThat(testRun.suiteRuns[0].specRuns[1].status).isEqualTo("skipped");
   }
 
   @Test
@@ -133,9 +314,10 @@ class TestParserTest {
 
     val result = parseReports(testRun = testRun, filePattern = testFile.toString(), verbose = true)
 
-    assertTrue(result.isSuccess)
-    val startTime = ZonedDateTime.parse("2023-01-01T09:00:00Z")
-    assertEquals(startTime.format(DateTimeFormatter.ISO_INSTANT), testRun.startTime?.format(DateTimeFormatter.ISO_INSTANT))
-    assertEquals(startTime.plusSeconds(1).plus(500, ChronoUnit.MILLIS).format(DateTimeFormatter.ISO_INSTANT), testRun.endTime?.format(DateTimeFormatter.ISO_INSTANT))
+    assertThat(result.isSuccess).isTrue();
+
+    val startTime = ZonedDateTime.parse("2023-01-01T09:00:00Z");
+    assertThat(testRun.startTime?.format(DateTimeFormatter.ISO_INSTANT)).isEqualTo(startTime.format(DateTimeFormatter.ISO_INSTANT));
+    assertThat(testRun.endTime?.format(DateTimeFormatter.ISO_INSTANT)).isEqualTo(startTime.plusSeconds(1).plus(500, ChronoUnit.MILLIS).format(DateTimeFormatter.ISO_INSTANT));
   }
 }


### PR DESCRIPTION
now supports multiple configurations

- `/**/*.xml`
- `/actual-file-name.xml`
- or even just `*.xml`

- update tests for new patterns and sub directory functionality