### PR TITLE
feat: update group name and package structure to match github repo url for gradle publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the plugin to your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("com.guidewire.fern-publisher") version "1.0.0"
+  id("io.github.guidewire-oss.fern-publisher") version "1.0.0"
 }
 ```
 
@@ -34,7 +34,7 @@ Or in `build.gradle`:
 
 ```groovy
 plugins {
-    id 'com.guidewire.fern-publisher' version '1.0.0'
+    id 'io.github.guidewire-oss.fern-publisher' version '1.0.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'  // Add this plugin to use publishing block
 }
 
-group = 'com.guidewire'
+group = 'io.github.guidewire-oss'
 version = '0.1.1'
 
 gradlePlugin {
@@ -15,11 +15,11 @@ gradlePlugin {
     vcsUrl = "https://github.com/guidewire-oss/fern-junit-gradle-plugin"
     plugins {
         create("fernPublisher") {
-            id = "com.guidewire.fern-publisher"
+            id = "io.github.guidewire-oss.fern-publisher"
             displayName = 'fern-publisher'
             description = 'This plugin simplifies the process of collecting JUnit XML test reports and publishing them to a Fern test reporting service. It parses JUnit XML reports, converts them to Fern\'s data model, and sends them to your Fern instance through its API. To learn more about Fern, check out its repository: https://github.com/guidewire-oss/fern-reporter'
             tags = ['testing', 'testing-tools', 'reporter', 'fern', 'test-reporter']
-            implementationClass = "com.guidewire.plugin.FernPublisherPlugin"
+            implementationClass = "io.github.guidewire.oss.plugin.FernPublisherPlugin"
         }
     }
 }

--- a/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
@@ -1,6 +1,6 @@
-package com.guidewire
+package io.github.guidewire.oss
 
-import com.guidewire.models.TestRun
+import io.github.guidewire.oss.models.TestRun
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy

--- a/src/main/kotlin/io/github/guidewire/oss/TestParser.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/TestParser.kt
@@ -1,16 +1,11 @@
-package com.guidewire
+package io.github.guidewire.oss
 
-import com.guidewire.models.*
-import com.guidewire.util.GlobalClock
+import io.github.guidewire.oss.models.*
+import io.github.guidewire.oss.util.GlobalClock
 import org.w3c.dom.Element
 import org.xml.sax.InputSource
 import java.io.File
-import java.nio.file.FileSystems
-import java.nio.file.Files
-import java.nio.file.NoSuchFileException
-import java.nio.file.Path
-import java.nio.file.PathMatcher
-import java.nio.file.Paths
+import java.nio.file.*
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/io/github/guidewire/oss/models/FernDataModels.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/models/FernDataModels.kt
@@ -1,4 +1,4 @@
-package com.guidewire.models
+package io.github.guidewire.oss.models
 
 import kotlinx.serialization.Serializable
 import java.time.ZonedDateTime

--- a/src/main/kotlin/io/github/guidewire/oss/models/JunitDataModels.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/models/JunitDataModels.kt
@@ -5,89 +5,89 @@ import org.gradle.internal.impldep.kotlinx.serialization.Serializable
 
 @Serializable
 data class TestSuites(
-    @SerialName("name")
-    val name: String = "",
+  @SerialName("name")
+  val name: String = "",
 
-    @SerialName("time")
-    val time: String = "",
+  @SerialName("time")
+  val time: String = "",
 
-    @SerialName("testsuite")
-    val testSuites: MutableList<TestSuite> = mutableListOf()
+  @SerialName("testsuite")
+  val testSuites: MutableList<TestSuite> = mutableListOf()
 )
 
 @Serializable
 data class TestSuite(
-    @SerialName("name")
-    val name: String = "",
+  @SerialName("name")
+  val name: String = "",
 
-    @SerialName("tests")
-    val tests: Int = 0,
+  @SerialName("tests")
+  val tests: Int = 0,
 
-    @SerialName("skipped")
-    val skipped: Int = 0,
+  @SerialName("skipped")
+  val skipped: Int = 0,
 
-    @SerialName("failures")
-    val failures: Int = 0,
+  @SerialName("failures")
+  val failures: Int = 0,
 
-    @SerialName("errors")
-    val errors: Int = 0,
+  @SerialName("errors")
+  val errors: Int = 0,
 
-    @SerialName("timestamp")
-    val timestamp: String = "",
+  @SerialName("timestamp")
+  val timestamp: String = "",
 
-    @SerialName("time")
-    val time: String = "",
+  @SerialName("time")
+  val time: String = "",
 
-    @SerialName("testcase")
-    val testCases: MutableList<TestCase> = mutableListOf()
+  @SerialName("testcase")
+  val testCases: MutableList<TestCase> = mutableListOf()
 )
 
 @Serializable
 data class TestCase(
   @SerialName("name")
-    val name: String = "",
+  val name: String = "",
 
   @SerialName("classname")
-    val className: String = "",
+  val className: String = "",
 
   @SerialName("time")
-    val time: String = "",
+  val time: String = "",
 
   @SerialName("failure")
-    val failures: List<Failure> = emptyList(),
+  val failures: List<Failure> = emptyList(),
 
   @SerialName("error")
-    val errors: List<Error> = emptyList(),
+  val errors: List<Error> = emptyList(),
 
   @SerialName("skipped")
-    val skips: List<Skip> = emptyList()
+  val skips: List<Skip> = emptyList()
 ) {
-    @Serializable
-    data class Failure(
-        @SerialName("message")
-        val message: String = "",
+  @Serializable
+  data class Failure(
+    @SerialName("message")
+    val message: String = "",
 
-        @SerialName("type")
-        val type: String = "",
+    @SerialName("type")
+    val type: String = "",
 
-        @Transient
-        val content: String = ""
-    )
+    @Transient
+    val content: String = ""
+  )
 
-    @Serializable
-    data class Error(
-        @SerialName("message")
-        val message: String = "",
+  @Serializable
+  data class Error(
+    @SerialName("message")
+    val message: String = "",
 
-        @SerialName("type")
-        val type: String = "",
+    @SerialName("type")
+    val type: String = "",
 
-        @Transient
-        val content: String = ""
-    )
+    @Transient
+    val content: String = ""
+  )
 
-    @Serializable
-    class Skip(
-        // Empty class to represent skip tag
-    ) {}
+  @Serializable
+  class Skip(
+    // Empty class to represent skip tag
+  ) {}
 }

--- a/src/main/kotlin/io/github/guidewire/oss/models/JunitDataModels.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/models/JunitDataModels.kt
@@ -1,4 +1,4 @@
-package com.guidewire.models
+package io.github.guidewire.oss.models
 
 import org.gradle.internal.impldep.kotlinx.serialization.SerialName
 import org.gradle.internal.impldep.kotlinx.serialization.Serializable
@@ -44,22 +44,22 @@ data class TestSuite(
 
 @Serializable
 data class TestCase(
-    @SerialName("name")
+  @SerialName("name")
     val name: String = "",
 
-    @SerialName("classname")
+  @SerialName("classname")
     val className: String = "",
 
-    @SerialName("time")
+  @SerialName("time")
     val time: String = "",
 
-    @SerialName("failure")
+  @SerialName("failure")
     val failures: List<Failure> = emptyList(),
 
-    @SerialName("error")
+  @SerialName("error")
     val errors: List<Error> = emptyList(),
 
-    @SerialName("skipped")
+  @SerialName("skipped")
     val skips: List<Skip> = emptyList()
 ) {
     @Serializable

--- a/src/main/kotlin/io/github/guidewire/oss/models/KZoneDateTimeSerializer.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/models/KZoneDateTimeSerializer.kt
@@ -1,4 +1,4 @@
-package com.guidewire.models
+package io.github.guidewire.oss.models
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind

--- a/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherExtension.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherExtension.kt
@@ -1,4 +1,4 @@
-package com.guidewire.plugin
+package io.github.guidewire.oss.plugin
 
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property

--- a/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherPlugin.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherPlugin.kt
@@ -1,4 +1,4 @@
-package com.guidewire.plugin
+package io.github.guidewire.oss.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/src/main/kotlin/io/github/guidewire/oss/plugin/PublishToFern.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/plugin/PublishToFern.kt
@@ -1,8 +1,8 @@
-package com.guidewire.plugin
+package io.github.guidewire.oss.plugin
 
-import com.guidewire.parseReports
-import com.guidewire.models.TestRun
-import com.guidewire.sendTestRun
+import io.github.guidewire.oss.parseReports
+import io.github.guidewire.oss.models.TestRun
+import io.github.guidewire.oss.sendTestRun
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property

--- a/src/main/kotlin/io/github/guidewire/oss/util/GlobalClock.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/util/GlobalClock.kt
@@ -1,4 +1,4 @@
-package com.guidewire.util
+package io.github.guidewire.oss.util
 
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter

--- a/src/test/kotlin/DataSenderTest.kt
+++ b/src/test/kotlin/DataSenderTest.kt
@@ -1,9 +1,9 @@
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import com.guidewire.models.SuiteRun
-import com.guidewire.models.TestRun
-import com.guidewire.sendTestRun
+import io.github.guidewire.oss.models.SuiteRun
+import io.github.guidewire.oss.models.TestRun
+import io.github.guidewire.oss.sendTestRun
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/FernPublisherPluginTest.kt
+++ b/src/test/kotlin/FernPublisherPluginTest.kt
@@ -1,8 +1,8 @@
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import com.guidewire.plugin.FernPublisherExtension
-import com.guidewire.plugin.PublishToFern
+import io.github.guidewire.oss.plugin.FernPublisherExtension
+import io.github.guidewire.oss.plugin.PublishToFern
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.GradleRunner
@@ -21,32 +21,32 @@ import java.nio.file.Path
 
 class FernPublisherPluginTest {
 
-    @TempDir
-    lateinit var projectDir: Path
+  @TempDir
+  lateinit var projectDir: Path
 
-    private lateinit var buildFile: File
-    private lateinit var testReportDir: File
-    private lateinit var wireMockServer: WireMockServer
+  private lateinit var buildFile: File
+  private lateinit var testReportDir: File
+  private lateinit var wireMockServer: WireMockServer
 
-    @BeforeEach
-    fun setup() {
-        buildFile = projectDir.resolve("build.gradle.kts").toFile()
-        testReportDir = projectDir.resolve("build/test-results/test").toFile()
-        testReportDir.mkdirs()
+  @BeforeEach
+  fun setup() {
+    buildFile = projectDir.resolve("build.gradle.kts").toFile()
+    testReportDir = projectDir.resolve("build/test-results/test").toFile()
+    testReportDir.mkdirs()
 
-        // Start mock server
-        wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
-        wireMockServer.start()
-        configureFor("localhost", wireMockServer.port())
+    // Start mock server
+    wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
+    wireMockServer.start()
+    configureFor("localhost", wireMockServer.port())
 
-        // Stub the API endpoint
-        stubFor(
-            post(urlEqualTo("/api/testrun/"))
-                .willReturn(aResponse().withStatus(200))
-        )
+    // Stub the API endpoint
+    stubFor(
+      post(urlEqualTo("/api/testrun/"))
+        .willReturn(aResponse().withStatus(200))
+    )
 
-        // Create sample test report
-        val sampleXml = """
+    // Create sample test report
+    val sampleXml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <testsuite name="SampleTest" tests="2" failures="0" errors="0" skipped="0" time="1.234">
                 <testcase name="testOne" time="0.5"/>
@@ -54,46 +54,47 @@ class FernPublisherPluginTest {
             </testsuite>
         """.trimIndent()
 
-        val reportFile = testReportDir.resolve("TEST-SampleTest.xml")
-        Files.write(reportFile.toPath(), sampleXml.toByteArray())
+    val reportFile = testReportDir.resolve("TEST-SampleTest.xml")
+    Files.write(reportFile.toPath(), sampleXml.toByteArray())
+  }
+
+  @AfterEach
+  fun tearDown() {
+    wireMockServer.stop()
+  }
+
+  @Test
+  fun `plugin should apply correctly to project`() {
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("io.github.guidewire-oss.fern-publisher")
+
+    assertTrue(project.tasks.findByName("publishToFern") is PublishToFern)
+  }
+
+  @Test
+  fun `plugin extension should configure task properties`() {
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("io.github.guidewire-oss.fern-publisher")
+
+    project.extensions.configure<FernPublisherExtension>("fernPublisher") {
+      it.fernUrl.set("http://example.com")
+      it.projectName.set("test-project")
+      it.reportPaths.set(listOf("build/reports/**/*.xml"))
     }
 
-    @AfterEach
-    fun tearDown() {
-        wireMockServer.stop()
-    }
+    val task = project.tasks.findByName("publishToFern") as PublishToFern
 
-    @Test
-    fun `plugin should apply correctly to project`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.guidewire.fern-publisher")
+    assertThat(task.fernUrl.get()).isEqualTo("http://example.com")
+    assertThat(task.projectName.get()).isEqualTo("test-project")
+    assertThat(task.reportPaths.get()).isEqualTo(listOf("build/reports/**/*.xml"))
+  }
 
-        assertTrue(project.tasks.findByName("publishToFern") is PublishToFern)
-    }
-
-    @Test
-    fun `plugin extension should configure task properties`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.guidewire.fern-publisher")
-
-        project.extensions.configure<FernPublisherExtension>("fernPublisher") {
-            it.fernUrl.set("http://example.com")
-            it.projectName.set("test-project")
-            it.reportPaths.set(listOf("build/reports/**/*.xml"))
-        }
-
-        val task = project.tasks.findByName("publishToFern") as PublishToFern
-        assertEquals("http://example.com", task.fernUrl.get())
-        assertEquals("test-project", task.projectName.get())
-        assertEquals(listOf("build/reports/**/*.xml"), task.reportPaths.get())
-    }
-
-    @Test
-    fun `task should successfully publish test results`() {
-        buildFile.writeText(
-            """
+  @Test
+  fun `task should successfully publish test results`() {
+    buildFile.writeText(
+      """
             plugins {
-                id("com.guidewire.fern-publisher")
+                id("io.github.guidewire-oss.fern-publisher")
             }
             
             fernPublisher {
@@ -103,38 +104,38 @@ class FernPublisherPluginTest {
                 verbose.set(true)
             }
         """.trimIndent()
-        )
+    )
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern", "--stacktrace")
-            .build()
+    val result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern", "--stacktrace")
+      .build()
 
-        // Verify task execution
-        assertTrue(result.output.contains("Executing PublishToFern"))
-        assertTrue(result.output.contains("Successfully published test results to Fern"))
+    // Verify task execution
+    assertThat(result.output).contains("Executing PublishToFern")
+    assertThat(result.output).contains("Successfully published test results to Fern")
 
-        // Verify the API was called
-        verify(
-            postRequestedFor(urlEqualTo("/api/testrun/"))
-                .withHeader("Content-Type", equalTo("application/json"))
-        )
-    }
+    // Verify the API was called
+    verify(
+      postRequestedFor(urlEqualTo("/api/testrun/"))
+        .withHeader("Content-Type", equalTo("application/json"))
+    )
+  }
 
-    @Test
-    fun `task should handle API errors`() {
-        // Reset stub to return an error
-        reset()
-        stubFor(
-            post(urlEqualTo("/api/testrun/"))
-                .willReturn(aResponse().withStatus(500))
-        )
+  @Test
+  fun `task should handle API errors`() {
+    // Reset stub to return an error
+    reset()
+    stubFor(
+      post(urlEqualTo("/api/testrun/"))
+        .willReturn(aResponse().withStatus(500))
+    )
 
-        buildFile.writeText(
-            """
+    buildFile.writeText(
+      """
             plugins {
-                id("com.guidewire.fern-publisher")
+                id("io.github.guidewire-oss.fern-publisher")
             }
             
             fernPublisher {
@@ -144,24 +145,24 @@ class FernPublisherPluginTest {
                 failOnError.set(true)
             }
         """.trimIndent()
-        )
+    )
 
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern")
+    val runner = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern")
 
-        val result = runner.buildAndFail()
+    val result = runner.buildAndFail()
 
-        assertTrue(result.output.contains("Failed to publish test results to Fern"))
-    }
+    assertThat(result.output).contains("Failed to publish test results to Fern")
+  }
 
-    @Test
-    fun `task should handle missing report files`() {
-        buildFile.writeText(
-            """
+  @Test
+  fun `task should handle missing report files`() {
+    buildFile.writeText(
+      """
             plugins {
-                id("com.guidewire.fern-publisher")
+                id("io.github.guidewire-oss.fern-publisher")
             }
             
             fernPublisher {
@@ -171,113 +172,113 @@ class FernPublisherPluginTest {
                 failOnError.set(true)
             }
         """.trimIndent()
-        )
-
-        val runner = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern")
-
-        val result = runner.buildAndFail()
-
-        assertTrue(result.output.contains("No files found"))
-    }
-
-    @Test
-    fun `task should fail when failOnError is true`() {
-        buildFile.writeText(
-            """
-            plugins {
-                id("com.guidewire.fern-publisher")
-            }
-            
-            fernPublisher {
-                fernUrl.set("http://localhost:${wireMockServer.port()}")
-                projectName.set("test-project")
-                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
-                verbose.set(true)
-                failOnError.set(true)
-            }
-        """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern", "--stacktrace")
-            .buildAndFail()
-
-        // Verify task execution
-        assertThat(result.output).contains("Failed to parse reports")
-    }
-
-    @Test
-    fun `task should NOT fail when failOnError is false but still log errors`() {
-        buildFile.writeText(
-            """
-            plugins {
-                id("com.guidewire.fern-publisher")
-            }
-            
-            fernPublisher {
-                fernUrl.set("http://localhost:${wireMockServer.port()}")
-                projectName.set("test-project")
-                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
-                verbose.set(true)
-            }
-        """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern", "--stacktrace")
-            .build()
-
-        // Verify task execution
-        assertThat(result.output).contains("Failed to parse reports")
-    }
-
-    @Test
-    fun `task should fail when both projectName and projectID are not configured`() {
-        buildFile.writeText(
-            """
-            plugins {
-                id("com.guidewire.fern-publisher")
-            }
-            
-            fernPublisher {
-                fernUrl.set("http://localhost:${wireMockServer.port()}")
-                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
-                verbose.set(true)
-                failOnError.set(true)
-            }
-        """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern", "--stacktrace")
-            .buildAndFail()
-
-        // Verify task execution
-        assertThat(result.output).contains("a projectId or a projectName must be specified")
-    }
-
-
-    @ParameterizedTest
-    @CsvSource(
-        "projectName,",
-        ",projectId",
-        "projectName,projectId"
     )
-    fun `task should accept either projectName, projectId, or both`(projectName: String?, projectId: String?) {
 
-        buildFile.writeText(
-            """
+    val runner = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern")
+
+    val result = runner.buildAndFail()
+
+    assertThat(result.output).contains("No files found")
+  }
+
+  @Test
+  fun `task should fail when failOnError is true`() {
+    buildFile.writeText(
+      """
             plugins {
-                id("com.guidewire.fern-publisher")
+                id("io.github.guidewire-oss.fern-publisher")
+            }
+            
+            fernPublisher {
+                fernUrl.set("http://localhost:${wireMockServer.port()}")
+                projectName.set("test-project")
+                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
+                verbose.set(true)
+                failOnError.set(true)
+            }
+        """.trimIndent()
+    )
+
+    val result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern", "--stacktrace")
+      .buildAndFail()
+
+    // Verify task execution
+    assertThat(result.output).contains("Failed to parse reports")
+  }
+
+  @Test
+  fun `task should NOT fail when failOnError is false but still log errors`() {
+    buildFile.writeText(
+      """
+            plugins {
+                id("io.github.guidewire-oss.fern-publisher")
+            }
+            
+            fernPublisher {
+                fernUrl.set("http://localhost:${wireMockServer.port()}")
+                projectName.set("test-project")
+                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
+                verbose.set(true)
+            }
+        """.trimIndent()
+    )
+
+    val result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern", "--stacktrace")
+      .build()
+
+    // Verify task execution
+    assertThat(result.output).contains("Failed to parse reports")
+  }
+
+  @Test
+  fun `task should fail when both projectName and projectID are not configured`() {
+    buildFile.writeText(
+      """
+            plugins {
+                id("io.github.guidewire-oss.fern-publisher")
+            }
+            
+            fernPublisher {
+                fernUrl.set("http://localhost:${wireMockServer.port()}")
+                reportPaths.set(listOf("build/test-results/fakePath/**/*.xml"))
+                verbose.set(true)
+                failOnError.set(true)
+            }
+        """.trimIndent()
+    )
+
+    val result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern", "--stacktrace")
+      .buildAndFail()
+
+    // Verify task execution
+    assertThat(result.output).contains("a projectId or a projectName must be specified")
+  }
+
+
+  @ParameterizedTest
+  @CsvSource(
+    "projectName,",
+    ",projectId",
+    "projectName,projectId"
+  )
+  fun `task should accept either projectName, projectId, or both`(projectName: String?, projectId: String?) {
+
+    buildFile.writeText(
+      """
+            plugins {
+                id("io.github.guidewire-oss.fern-publisher")
             }
             
             fernPublisher {
@@ -288,22 +289,22 @@ class FernPublisherPluginTest {
                 verbose.set(true)
             }
         """.trimIndent()
-        )
+    )
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withPluginClasspath()
-            .withArguments("publishToFern", "--stacktrace")
-            .build()
+    val result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+      .withArguments("publishToFern", "--stacktrace")
+      .build()
 
-        // Verify task execution
-        assertTrue(result.output.contains("Executing PublishToFern"))
-        assertTrue(result.output.contains("Successfully published test results to Fern"))
+    // Verify task execution
+    assertThat(result.output).contains("Executing PublishToFern")
+    assertThat(result.output).contains("Successfully published test results to Fern")
 
-        // Verify the API was called
-        verify(
-            postRequestedFor(urlEqualTo("/api/testrun/"))
-                .withHeader("Content-Type", equalTo("application/json"))
-        )
-    }
+    // Verify the API was called
+    verify(
+      postRequestedFor(urlEqualTo("/api/testrun/"))
+        .withHeader("Content-Type", equalTo("application/json"))
+    )
+  }
 }

--- a/src/test/kotlin/TestParserTest.kt
+++ b/src/test/kotlin/TestParserTest.kt
@@ -1,7 +1,7 @@
-import com.guidewire.models.TestRun
-import com.guidewire.parseReports
-import com.guidewire.util.GlobalClock
-import com.guidewire.util.MockClock
+import io.github.guidewire.oss.models.TestRun
+import io.github.guidewire.oss.parseReports
+import io.github.guidewire.oss.util.GlobalClock
+import io.github.guidewire.oss.util.MockClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated the group name, plugin ID, and all package names to use io.github.guidewire.oss, matching the GitHub repository URL for Gradle publishing. Updated documentation and imports to reflect the new structure.

<!-- End of auto-generated description by mrge. -->

