### PR TITLE
Feature/#19 support oauth fern platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,21 +117,37 @@ fernPublisher {
 If your Fern instance requires OAuth authentication, you can configure it using environment variables:
 
 ```bash
-export OAUTH_TOKEN_URL="https://auth.example.com/token"
-export OAUTH_CLIENT_ID="your-client-id"
-export OAUTH_CLIENT_PASSWORD="your-client-secret"
-export OAUTH_SCOPES="fern.write fernproject.myproject"
+export AUTH_URL="https://auth.example.com/token"
+export FERN_AUTH_CLIENT_ID="your-client-id"
+export FERN_AUTH_CLIENT_SECRET="your-client-secret"
+export FERN_CLIENT_SCOPE="fern.write fernproject.myproject"
 ```
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| OAUTH_TOKEN_URL | OAuth token endpoint URL | Yes (if auth enabled) |
-| OAUTH_CLIENT_ID | OAuth client identifier | Yes (if auth enabled) |
-| OAUTH_CLIENT_PASSWORD | OAuth client secret | Yes (if auth enabled) |
-| OAUTH_SCOPES | Space-separated OAuth scopes (e.g., `fern.write fern.read`) | Yes (if auth enabled) |
+| AUTH_URL | OAuth token endpoint URL. Setting this enables OAuth. | Yes (to enable auth) |
+| FERN_AUTH_CLIENT_ID | OAuth client identifier | Yes (if `AUTH_URL` is set) |
+| FERN_AUTH_CLIENT_SECRET | OAuth client secret | Yes (if `AUTH_URL` is set) |
+| FERN_CLIENT_SCOPE | Space-separated OAuth scopes (e.g., `fern.write fern.read`) | No |
 
-The plugin will automatically use these environment variables when making API calls to your Fern instance.
-Note: You can configure these in your build.gradle but is not recommended due to secret nature.
+OAuth is enabled when `AUTH_URL` is set; if it is set, `FERN_AUTH_CLIENT_ID` and
+`FERN_AUTH_CLIENT_SECRET` are required and the plugin will fail fast if either is missing.
+The plugin uses the OAuth 2.0 client credentials flow and adds the bearer token to API calls.
+
+Alternatively, you can configure OAuth in your `build.gradle` via the `fernPublisher` extension.
+Prefer sourcing secrets from the environment rather than hardcoding them:
+
+```gradle
+fernPublisher {
+    authUrl          = System.getenv("AUTH_URL")
+    authClientId     = System.getenv("FERN_AUTH_CLIENT_ID")
+    authClientSecret = System.getenv("FERN_AUTH_CLIENT_SECRET")
+    authScopes       = "fern.write fernproject.myproject"
+}
+```
+
+If `authUrl` is set in the extension it takes precedence; the environment variables above are
+used as a fallback when `authUrl` is left blank.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -232,25 +232,46 @@ cd fern-junit-publisher
 
 ## Development
 
-You can build and publish this plugin for use locally with the command
+### Publishing to Local Maven Repository
+
+To test the plugin locally during development, you can publish it to your local Maven repository (`.m2`).
+
+**Important:** You must specify a version number when publishing. Use the latest released version or the next version you plan to release.
 
 ```bash
-./gradlew publishToMavenLocal
+./gradlew publishToMavenLocal -Pversion=1.1.0
 ```
 
-You should see the plugin in your local `.m2` repository.
+The plugin will be published to your local `.m2` repository at:
+```
+~/.m2/repository/io/github/guidewire-oss/fern-junit-gradle-plugin/1.1.0/
+```
 
-From there you can set up a test project to use the plugin. Make sure to edit your `settings.gradle` file to use plugins
-found in your local m2 repository.
+### Using the Local Plugin in a Test Project
 
-```gradle
+To use your locally published plugin in a test project:
+
+1. Configure your test project's `settings.gradle` (or `settings.gradle.kts`) to use `mavenLocal()`:
+
+```groovy
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal()  // Check local repository first
         mavenCentral()
     }
 }
 ```
+
+2. Apply the plugin in your test project's `build.gradle`:
+
+```groovy
+plugins {
+    id 'io.github.guidewire-oss.fern-publisher' version '1.1.0'
+}
+```
+
+3. Configure and test the plugin as described in the [Configuration](#configuration) section.
+
 ### Building the CLI
 Native CLI binaries are built using GraalVM's native-image tool. This allows the CLI to run without requiring a Java runtime, making it lightweight and portable.
 
@@ -259,7 +280,7 @@ For building the CLI, you will need to have GraalVM installed and set the enviro
 Once that is set up, run the following command in the project root:
 
 ```bash
-./gradlew nativeImage -Pversion="1.0.0-SNAPSHOT"
+./gradlew nativeImage -Pversion="1.1.0"
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -111,6 +111,28 @@ fernPublisher {
 | verbose     | Enable verbose logging                                                                                                                                                    | No       | false      |
 | failOnError | When true, will fail when error is thrown. Errors will always log.                                                                                                        | No       | false      |
 
+
+### Authentication (Optional)
+
+If your Fern instance requires OAuth authentication, you can configure it using environment variables:
+
+```bash
+export OAUTH_TOKEN_URL="https://auth.example.com/token"
+export OAUTH_CLIENT_ID="your-client-id"
+export OAUTH_CLIENT_PASSWORD="your-client-secret"
+export OAUTH_SCOPES="fern.write fernproject.myproject"
+```
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| OAUTH_TOKEN_URL | OAuth token endpoint URL | Yes (if auth enabled) |
+| OAUTH_CLIENT_ID | OAuth client identifier | Yes (if auth enabled) |
+| OAUTH_CLIENT_PASSWORD | OAuth client secret | Yes (if auth enabled) |
+| OAUTH_SCOPES | Space-separated OAuth scopes (e.g., `fern.write fern.read`) | Yes (if auth enabled) |
+
+The plugin will automatically use these environment variables when making API calls to your Fern instance.
+
+
 ## Usage
 
 Run the task to publish test results:
@@ -237,5 +259,70 @@ For building the CLI, you will need to have GraalVM installed and set the enviro
 Once that is set up, run the following command in the project root:
 
 ```bash
-./gradlew nativeImage -Pversion="1.0.0-SNAPSHOT" 
+./gradlew nativeImage -Pversion="1.0.0-SNAPSHOT"
 ```
+
+## Testing
+
+This project uses JUnit 5 (Jupiter) for testing along with AssertJ for assertions, WireMock for HTTP mocking, and Gradle TestKit for plugin testing.
+
+### Running Tests
+
+Run all tests:
+```bash
+./gradlew test
+```
+
+Run tests with verbose output:
+```bash
+./gradlew test --info
+```
+
+Run a specific test class:
+```bash
+./gradlew test --tests TestParserTest
+./gradlew test --tests DataSenderTest
+./gradlew test --tests FernPublisherPluginTest
+```
+
+Run a specific test method:
+```bash
+./gradlew test --tests "TestParserTest.parseReports should handle empty file pattern"
+```
+
+Continuous testing (watches for changes):
+```bash
+./gradlew test --continuous
+```
+
+Clean and test:
+```bash
+./gradlew clean test
+```
+
+### Test Structure
+
+The project includes three main test suites located in `src/test/kotlin/`:
+
+- **TestParserTest.kt** - Tests JUnit XML parsing logic, including:
+  - Parsing various JUnit XML formats
+  - Handling empty file patterns
+  - Timezone handling
+  - Test suite and test case extraction
+
+- **DataSenderTest.kt** - Tests HTTP client and API communication, including:
+  - Sending test data to Fern Reporter API
+  - HTTP retry logic
+  - Error handling and redirects
+
+- **FernPublisherPluginTest.kt** - Tests Gradle plugin functionality, including:
+  - Plugin configuration
+  - Task registration
+  - Integration with Gradle build lifecycle
+
+### Test Dependencies
+
+- **JUnit Jupiter** (JUnit 5) - Testing framework
+- **AssertJ** - Fluent assertion library
+- **WireMock** - HTTP service mocking
+- **Gradle TestKit** - Gradle plugin testing framework

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ export OAUTH_SCOPES="fern.write fernproject.myproject"
 | OAUTH_SCOPES | Space-separated OAuth scopes (e.g., `fern.write fern.read`) | Yes (if auth enabled) |
 
 The plugin will automatically use these environment variables when making API calls to your Fern instance.
+Note: You can configure these in your build.gradle but is not recommended due to secret nature.
 
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'io.github.guidewire-oss'
-version = project.hasProperty('version') ? project.version : '1.0.0'
+version = project.hasProperty('version') ? project.version : '1.1.0'
 
 def os = DefaultNativePlatform.currentOperatingSystem
 def arch = DefaultNativePlatform.currentArchitecture

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ plugins {
 }
 
 group = 'io.github.guidewire-oss'
-version = project.hasProperty('version') ? project.version : '1.1.0'
+// Only use user-supplied version if provided; otherwise default
+version = (findProperty('version') ?: '1.1.0')
 
 def os = DefaultNativePlatform.currentOperatingSystem
 def arch = DefaultNativePlatform.currentArchitecture

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
   testImplementation "org.assertj:assertj-core:3.27.3"
   testImplementation "org.junit.jupiter:junit-jupiter:5.9.2"
   testImplementation "org.wiremock:wiremock:3.12.1"
+  testImplementation "uk.org.webcompere:system-stubs-jupiter:2.1.6"
   testImplementation gradleTestKit()
 
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,9 @@ plugins {
 }
 
 group = 'io.github.guidewire-oss'
-// Only use user-supplied version if provided; otherwise default
+// Only use user-supplied version if provided; otherwise default (updated)
 version = (findProperty('version') ?: '1.1.0')
+
 
 def os = DefaultNativePlatform.currentOperatingSystem
 def arch = DefaultNativePlatform.currentArchitecture

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+version=1.1.0

--- a/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
@@ -68,7 +68,7 @@ fun sendTestRun(
         }
       }
 
-      response = postTestRun(endpoint, fernUrl, payload, oauthClient, verbose)
+      response = postTestRun(endpoint, fernUrl, payload, oauthClient, verbose, maxRedirects = 5)
       if (response.statusCode() < 300) {
         break
       } else {
@@ -89,7 +89,9 @@ private fun postTestRun(
   fernUrl: String,
   payload: String,
   oauthClient: OAuthClient?,
-  verbose: Boolean
+  verbose: Boolean,
+  maxRedirects: Int = 5,
+  redirectCount: Int = 0
 ): HttpResponse<String> {
   val client = HttpClient.newBuilder()
     .connectTimeout(Duration.ofSeconds(30))
@@ -117,12 +119,16 @@ private fun postTestRun(
 
   var response = client.send(request, HttpResponse.BodyHandlers.ofString())
   if (response.statusCode() == 307) {
+    if (redirectCount >= maxRedirects) {
+      throw RuntimeException("Too many redirects: exceeded maximum of $maxRedirects")
+    }
+    
     val locationHeader = response.headers().firstValue("location").orElseThrow {
       RuntimeException("Location header not found in 307 response")
     }
 
     // Validate and resolve redirect location to prevent open redirects
-    val baseUri = URI(fernUrl)
+    val baseUri = URI(endpoint)
     val redirectUri = URI(locationHeader)
 
     val baseHost = baseUri.host?.lowercase()
@@ -139,7 +145,7 @@ private fun postTestRun(
       baseUri.resolve(redirectUri).normalize()
     }
 
-    response = postTestRun(resolvedUri.toString(), fernUrl, payload, oauthClient, verbose)
+    response = postTestRun(resolvedUri.toString(), fernUrl, payload, oauthClient, verbose, maxRedirects, redirectCount + 1)
   }
   return response
 }

--- a/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
@@ -1,5 +1,7 @@
 package io.github.guidewire.oss
 
+import io.github.guidewire.oss.auth.OAuthClient
+import io.github.guidewire.oss.auth.OAuthConfig
 import io.github.guidewire.oss.models.TestRun
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -8,11 +10,38 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.time.Duration
 
 @OptIn(ExperimentalSerializationApi::class)
-fun sendTestRun(testRun: TestRun, fernUrl: String, verbose: Boolean): Result<Unit> {
+fun sendTestRun(
+  testRun: TestRun,
+  fernUrl: String,
+  verbose: Boolean,
+  oauthConfig: OAuthConfig? = null,
+  apiEndpointPath: String? = null
+): Result<Unit> {
   return runCatching {
     var response: HttpResponse<String>? = null
+
+    // Create OAuth client if config is provided
+    val oauthClient = if (oauthConfig != null) {
+      if (verbose) {
+        println("OAuth authentication is enabled, initializing OAuth client...")
+      }
+      OAuthClient.fromConfig(oauthConfig)
+    } else {
+      // Also check environment variables for OAuth configuration
+      try {
+        val envClient = OAuthClient.fromEnvironment()
+        if (envClient != null && verbose) {
+          println("OAuth authentication enabled from environment variables")
+        }
+        envClient
+      } catch (e: Exception) {
+        // OAuth configuration error from environment
+        throw RuntimeException("OAuth configuration error: ${e.message}", e)
+      }
+    }
 
     for (i in 0..2) {
       val json = Json {
@@ -22,13 +51,24 @@ fun sendTestRun(testRun: TestRun, fernUrl: String, verbose: Boolean): Result<Uni
       }
 
       val payload = json.encodeToString(testRun)
-      val endpoint = "$fernUrl/api/testrun/"
+
+      // Use the provided API endpoint path, or check environment variable, or use default
+      val effectiveApiPath = apiEndpointPath
+        ?: System.getenv("FERN_API_ENDPOINT_PATH")
+        ?: "api/v1/test-runs"
+
+      val endpoint = "${fernUrl.removeSuffix("/")}/$effectiveApiPath"
 
       if (verbose) {
         println("Sending POST request to $endpoint...")
+        if (oauthClient != null) {
+          println("Using OAuth authentication")
+        } else {
+          println("OAuth authentication is not configured, proceeding without authentication")
+        }
       }
 
-      response = postTestRun(endpoint, fernUrl, payload)
+      response = postTestRun(endpoint, fernUrl, payload, oauthClient, verbose)
       if (response.statusCode() < 300) {
         break
       } else {
@@ -44,18 +84,43 @@ fun sendTestRun(testRun: TestRun, fernUrl: String, verbose: Boolean): Result<Uni
   }
 }
 
-private fun postTestRun(endpoint: String, fernUrl: String, payload: String): HttpResponse<String> {
-  val client = HttpClient.newBuilder().build()
-  val request = HttpRequest.newBuilder()
+private fun postTestRun(
+  endpoint: String,
+  fernUrl: String,
+  payload: String,
+  oauthClient: OAuthClient?,
+  verbose: Boolean
+): HttpResponse<String> {
+  val client = HttpClient.newBuilder()
+    .connectTimeout(Duration.ofSeconds(30))
+    .build()
+
+  val requestBuilder = HttpRequest.newBuilder()
     .uri(URI(endpoint).normalize())
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(payload))
-    .build()
+    .timeout(Duration.ofSeconds(30))
+
+  // Add OAuth authentication if enabled
+  if (oauthClient != null) {
+    try {
+      oauthClient.addAuthHeader(requestBuilder)
+      if (verbose) {
+        println("Added OAuth bearer token to request")
+      }
+    } catch (e: Exception) {
+      throw RuntimeException("Failed to add OAuth authentication: ${e.message}", e)
+    }
+  }
+
+  val request = requestBuilder.build()
 
   var response = client.send(request, HttpResponse.BodyHandlers.ofString())
   if (response.statusCode() == 307) {
-    val locationHeader = response.headers().firstValue("location").orElseThrow { RuntimeException("Location header not found in 307 response") }
-    response = postTestRun(fernUrl + locationHeader, fernUrl, payload)
+    val locationHeader = response.headers().firstValue("location").orElseThrow {
+      RuntimeException("Location header not found in 307 response")
+    }
+    response = postTestRun(fernUrl + locationHeader, fernUrl, payload, oauthClient, verbose)
   }
   return response
 }

--- a/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/DataSender.kt
@@ -120,7 +120,26 @@ private fun postTestRun(
     val locationHeader = response.headers().firstValue("location").orElseThrow {
       RuntimeException("Location header not found in 307 response")
     }
-    response = postTestRun(fernUrl + locationHeader, fernUrl, payload, oauthClient, verbose)
+
+    // Validate and resolve redirect location to prevent open redirects
+    val baseUri = URI(fernUrl)
+    val redirectUri = URI(locationHeader)
+
+    val baseHost = baseUri.host?.lowercase()
+    val redirectHost = redirectUri.host?.lowercase()
+
+    val resolvedUri = if (redirectUri.isAbsolute) {
+      // Only follow absolute redirects that stay on the same scheme and host as the base URI
+      if (redirectUri.scheme != baseUri.scheme || redirectHost != baseHost) {
+        throw RuntimeException("Refusing to follow redirect to untrusted host: $redirectUri")
+      }
+      redirectUri.normalize()
+    } else {
+      // Relative redirect: resolve against the trusted base URI
+      baseUri.resolve(redirectUri).normalize()
+    }
+
+    response = postTestRun(resolvedUri.toString(), fernUrl, payload, oauthClient, verbose)
   }
   return response
 }

--- a/src/main/kotlin/io/github/guidewire/oss/auth/OAuthClient.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/auth/OAuthClient.kt
@@ -145,7 +145,7 @@ class OAuthClient private constructor(private val config: OAuthConfig) {
         // Store the token and calculate expiry
         token = tokenResp
         // Subtract 30 seconds from expiry to ensure we refresh before it actually expires
-        val expiryDuration = Duration.ofSeconds((tokenResp.expiresIn - 30).toLong())
+        val expiryDuration = Duration.ofSeconds((tokenResp.expiresIn - 30).coerceAtLeast(1).toLong())
         tokenExpiry = Instant.now().plus(expiryDuration)
     }
 
@@ -155,15 +155,6 @@ class OAuthClient private constructor(private val config: OAuthConfig) {
     fun addAuthHeader(requestBuilder: HttpRequest.Builder) {
         val token = getToken()
         requestBuilder.header("Authorization", "Bearer $token")
-    }
-
-    /**
-     * Creates an HTTP client with OAuth authentication
-     */
-    fun createAuthenticatedClient(): HttpClient {
-        return HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(30))
-            .build()
     }
 
     private fun urlEncode(value: String): String {

--- a/src/main/kotlin/io/github/guidewire/oss/auth/OAuthClient.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/auth/OAuthClient.kt
@@ -1,0 +1,172 @@
+package io.github.guidewire.oss.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.time.Instant
+import kotlinx.serialization.json.Json
+
+/**
+ * OAuth configuration for client credentials flow
+ */
+data class OAuthConfig(
+    val tokenUrl: String,
+    val clientId: String,
+    val clientSecret: String,
+    val scopes: String = ""
+)
+
+/**
+ * OAuth token response from the token endpoint
+ */
+@Serializable
+data class TokenResponse(
+    @SerialName("access_token")
+    val accessToken: String,
+    @SerialName("token_type")
+    val tokenType: String,
+    @SerialName("expires_in")
+    val expiresIn: Int,
+    @SerialName("scope")
+    val scope: String? = null
+)
+
+/**
+ * OAuth client for handling client credentials flow authentication
+ * Supports token caching and automatic refresh
+ */
+class OAuthClient private constructor(private val config: OAuthConfig) {
+    private var token: TokenResponse? = null
+    private var tokenExpiry: Instant = Instant.MIN
+
+    companion object {
+        /**
+         * Creates a new OAuth client from environment variables
+         * Returns null if OAuth is not configured (AUTH_URL not set)
+         * Throws exception if AUTH_URL is set but required parameters are missing
+         */
+        fun fromEnvironment(): OAuthClient? {
+            val tokenUrl = System.getenv("AUTH_URL") ?: return null
+
+            // If AUTH_URL is set, validate that we have all required OAuth parameters
+            val missingParams = mutableListOf<String>()
+            val clientId = System.getenv("FERN_AUTH_CLIENT_ID")
+            val clientSecret = System.getenv("FERN_AUTH_CLIENT_SECRET")
+
+            if (clientId == null) {
+                missingParams.add("FERN_AUTH_CLIENT_ID")
+            }
+            if (clientSecret == null) {
+                missingParams.add("FERN_AUTH_CLIENT_SECRET")
+            }
+
+            if (missingParams.isNotEmpty()) {
+                throw IllegalStateException(
+                    "OAuth configuration error: AUTH_URL is set but missing required parameters: ${missingParams.joinToString(", ")}"
+                )
+            }
+
+            val scopes = System.getenv("FERN_CLIENT_SCOPE") ?: ""
+
+            return OAuthClient(
+                OAuthConfig(
+                    tokenUrl = tokenUrl,
+                    clientId = clientId!!,
+                    clientSecret = clientSecret!!,
+                    scopes = scopes
+                )
+            )
+        }
+
+        /**
+         * Creates a new OAuth client from explicit configuration
+         */
+        fun fromConfig(config: OAuthConfig): OAuthClient {
+            return OAuthClient(config)
+        }
+    }
+
+    /**
+     * Gets a valid access token, fetching a new one if necessary
+     */
+    fun getToken(): String {
+        // Check if we have a valid cached token
+        if (token != null && Instant.now().isBefore(tokenExpiry)) {
+            return token!!.accessToken
+        }
+
+        // Fetch new token
+        fetchToken()
+        return token!!.accessToken
+    }
+
+    /**
+     * Fetches a new access token using client credentials flow
+     */
+    private fun fetchToken() {
+        // Prepare the token request body
+        val formData = buildString {
+            append("grant_type=").append(urlEncode("client_credentials"))
+            append("&client_id=").append(urlEncode(config.clientId))
+            append("&client_secret=").append(urlEncode(config.clientSecret))
+            if (config.scopes.isNotEmpty()) {
+                append("&scope=").append(urlEncode(config.scopes))
+            }
+        }
+
+        val client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build()
+
+        val request = HttpRequest.newBuilder()
+            .uri(URI(config.tokenUrl))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .POST(HttpRequest.BodyPublishers.ofString(formData))
+            .timeout(Duration.ofSeconds(30))
+            .build()
+
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            throw RuntimeException(
+                "Failed to fetch OAuth token: HTTP ${response.statusCode()} - ${response.body()}"
+            )
+        }
+
+        // Parse the token response
+        val json = Json { ignoreUnknownKeys = true }
+        val tokenResp = json.decodeFromString<TokenResponse>(response.body())
+
+        // Store the token and calculate expiry
+        token = tokenResp
+        // Subtract 30 seconds from expiry to ensure we refresh before it actually expires
+        val expiryDuration = Duration.ofSeconds((tokenResp.expiresIn - 30).toLong())
+        tokenExpiry = Instant.now().plus(expiryDuration)
+    }
+
+    /**
+     * Adds the OAuth bearer token to the given HTTP request builder
+     */
+    fun addAuthHeader(requestBuilder: HttpRequest.Builder) {
+        val token = getToken()
+        requestBuilder.header("Authorization", "Bearer $token")
+    }
+
+    /**
+     * Creates an HTTP client with OAuth authentication
+     */
+    fun createAuthenticatedClient(): HttpClient {
+        return HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build()
+    }
+
+    private fun urlEncode(value: String): String {
+        return URLEncoder.encode(value, Charsets.UTF_8)
+    }
+}

--- a/src/main/kotlin/io/github/guidewire/oss/cli/SendCommand.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/cli/SendCommand.kt
@@ -25,6 +25,15 @@ class SendCommand : CliktCommand(
   private val tags by option("-t", "--tags", help = "Comma-separated tags to be included on runs")
   private val verbose by option("-v", "--verbose", help = "Enable verbose output").flag()
 
+  // OAuth options
+  private val authUrl by option("--auth-url", help = "OAuth 2.0 token endpoint URL (enables OAuth if set)")
+  private val authClientId by option("--auth-client-id", help = "OAuth client ID")
+  private val authClientSecret by option("--auth-client-secret", help = "OAuth client secret")
+  private val authScopes by option("--auth-scopes", help = "Space-separated OAuth scopes")
+
+  // API endpoint path option
+  private val apiEndpointPath by option("--api-endpoint-path", help = "Custom API endpoint path (default: api/v1/test-runs)")
+
   override fun run() {
     try {
       echo("Reading reports from: ${filePatterns.joinToString(":")}")
@@ -68,7 +77,29 @@ class SendCommand : CliktCommand(
         exitProcess(1)
       }
 
-      sendTestRun(testRun, fernUrl, verbose).fold(
+      // Create OAuth config if auth URL is provided
+      val oauthConfig = if (authUrl != null) {
+        if (authClientId == null || authClientSecret == null) {
+          echo("ERROR: --auth-url is set but --auth-client-id or --auth-client-secret is missing", err = true)
+          exitProcess(1)
+        }
+        io.github.guidewire.oss.auth.OAuthConfig(
+          tokenUrl = authUrl!!,
+          clientId = authClientId!!,
+          clientSecret = authClientSecret!!,
+          scopes = authScopes ?: ""
+        )
+      } else {
+        null
+      }
+
+      sendTestRun(
+        testRun = testRun,
+        fernUrl = fernUrl,
+        verbose = verbose,
+        oauthConfig = oauthConfig,
+        apiEndpointPath = apiEndpointPath
+      ).fold(
         onSuccess = {
           echo("Successfully published test results to Fern")
         },

--- a/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherExtension.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherExtension.kt
@@ -13,10 +13,28 @@ abstract class FernPublisherExtension {
   abstract val verbose: Property<Boolean>
   abstract val failOnError: Property<Boolean>
 
+  // OAuth configuration
+  abstract val authUrl: Property<String>
+  abstract val authClientId: Property<String>
+  abstract val authClientSecret: Property<String>
+  abstract val authScopes: Property<String>
+
+  // API endpoint path configuration
+  abstract val apiEndpointPath: Property<String>
+
   init {
     fernTags.convention(listOf())
     verbose.convention(false)
     failOnError.convention(false)
     projectName.convention("")
+
+    // OAuth defaults - empty means OAuth is disabled
+    authUrl.convention("")
+    authClientId.convention("")
+    authClientSecret.convention("")
+    authScopes.convention("")
+
+    // API endpoint path default - use v1 API by default
+    apiEndpointPath.convention("api/v1/test-runs")
   }
 }

--- a/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherPlugin.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/plugin/FernPublisherPlugin.kt
@@ -19,6 +19,11 @@ class FernPublisherPlugin : Plugin<Project> {
       extension.fernTags.orNull?.let { task.fernTags.set(it) }
       extension.verbose.orNull?.let { task.verbose.set(it) }
       extension.failOnError.orNull?.let {task.failOnError.set(it) }
+      extension.authUrl.orNull?.let { task.authUrl.set(it) }
+      extension.authClientId.orNull?.let { task.authClientId.set(it) }
+      extension.authClientSecret.orNull?.let { task.authClientSecret.set(it) }
+      extension.authScopes.orNull?.let { task.authScopes.set(it) }
+      extension.apiEndpointPath.orNull?.let { task.apiEndpointPath.set(it) }
       task.projectDir.set(project.projectDir.absolutePath + "/")
     }
   }

--- a/src/main/kotlin/io/github/guidewire/oss/plugin/PublishToFern.kt
+++ b/src/main/kotlin/io/github/guidewire/oss/plugin/PublishToFern.kt
@@ -42,6 +42,26 @@ abstract class PublishToFern : DefaultTask() {
   @get:Optional
   abstract val failOnError: Property<Boolean>
 
+  @get:Input
+  @get:Optional
+  abstract val authUrl: Property<String>
+
+  @get:Input
+  @get:Optional
+  abstract val authClientId: Property<String>
+
+  @get:Input
+  @get:Optional
+  abstract val authClientSecret: Property<String>
+
+  @get:Input
+  @get:Optional
+  abstract val authScopes: Property<String>
+
+  @get:Input
+  @get:Optional
+  abstract val apiEndpointPath: Property<String>
+
   init {
     fernTags.convention(listOf()) // Set default value
     verbose.convention(false)
@@ -49,6 +69,11 @@ abstract class PublishToFern : DefaultTask() {
     failOnError.convention(false)
     projectName.convention("")
     projectId.convention("")
+    authUrl.convention("")
+    authClientId.convention("")
+    authClientSecret.convention("")
+    authScopes.convention("")
+    apiEndpointPath.convention("api/v1/test-runs")
   }
 
   @TaskAction
@@ -123,7 +148,33 @@ abstract class PublishToFern : DefaultTask() {
 
     logger.lifecycle("Found ${testRun.suiteRuns.size} test suites with a total of ${testRun.suiteRuns.sumOf { it.specRuns.size }} test specs")
 
-    sendTestRun(testRun, fernUrl, isVerbose).fold(
+    // Create OAuth config if auth URL is provided
+    val oauthConfig = if (authUrl.get().isNotBlank()) {
+      if (authClientId.get().isBlank() || authClientSecret.get().isBlank()) {
+        logger.error("OAuth configuration error: authUrl is set but authClientId or authClientSecret is missing")
+        if (failOnError.get()) {
+          throw IllegalArgumentException("OAuth configuration error: authUrl is set but authClientId or authClientSecret is missing")
+        }
+        null
+      } else {
+        io.github.guidewire.oss.auth.OAuthConfig(
+          tokenUrl = authUrl.get(),
+          clientId = authClientId.get(),
+          clientSecret = authClientSecret.get(),
+          scopes = authScopes.get()
+        )
+      }
+    } else {
+      null
+    }
+
+    sendTestRun(
+      testRun = testRun,
+      fernUrl = fernUrl,
+      verbose = isVerbose,
+      oauthConfig = oauthConfig,
+      apiEndpointPath = apiEndpointPath.get()
+    ).fold(
       onSuccess = {
         logger.lifecycle("Successfully published test results to Fern")
       },

--- a/src/test/kotlin/DataSenderTest.kt
+++ b/src/test/kotlin/DataSenderTest.kt
@@ -1,6 +1,7 @@
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import io.github.guidewire.oss.auth.OAuthConfig
 import io.github.guidewire.oss.models.SuiteRun
 import io.github.guidewire.oss.models.TestRun
 import io.github.guidewire.oss.sendTestRun
@@ -132,5 +133,337 @@ class DataSenderTest {
 
     // Verify
     assertTrue(result.isFailure)
+  }
+
+  @Test
+  fun `sendTestRun should include Authorization header with OAuth config`() {
+    // Setup OAuth token endpoint
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "test-oauth-token-123",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    // Setup test data endpoint
+    stubFor(
+      post(urlEqualTo("/api/v1/test-runs"))
+        .withHeader("Content-Type", equalTo("application/json"))
+        .withHeader("Authorization", equalTo("Bearer test-oauth-token-123"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody("{\"status\":\"success\"}")
+        )
+    )
+
+    // Create OAuth config
+    val oauthConfig = OAuthConfig(
+      tokenUrl = "http://localhost:${wireMockServer.port()}/oauth/token",
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret",
+      scopes = "fern.write"
+    )
+
+    // Test API call with OAuth
+    val result = sendTestRun(
+      testRun,
+      "http://localhost:${wireMockServer.port()}",
+      verbose = true,
+      oauthConfig = oauthConfig
+    )
+
+    // Verify success
+    assertTrue(result.isSuccess)
+
+    // Verify OAuth token was requested
+    verify(
+      postRequestedFor(urlEqualTo("/oauth/token"))
+        .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+    )
+
+    // Verify test run was sent with Authorization header
+    verify(
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
+        .withHeader("Content-Type", equalTo("application/json"))
+        .withHeader("Authorization", equalTo("Bearer test-oauth-token-123"))
+    )
+  }
+
+  @Test
+  fun `sendTestRun should work without authentication when OAuth not configured`() {
+    // Setup mock server without OAuth requirement
+    stubFor(
+      post(urlEqualTo("/api/v1/test-runs"))
+        .withHeader("Content-Type", equalTo("application/json"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody("{\"status\":\"success\"}")
+        )
+    )
+
+    // Test API call without OAuth
+    val result = sendTestRun(testRun, "http://localhost:${wireMockServer.port()}", true)
+
+    // Verify
+    assertTrue(result.isSuccess)
+    verify(
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
+        .withHeader("Content-Type", equalTo("application/json"))
+    )
+
+    // Verify no Authorization header was sent
+    verify(
+      0,
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
+        .withHeader("Authorization", matching(".*"))
+    )
+  }
+
+  @Test
+  fun `sendTestRun should handle OAuth token fetch failures`() {
+    // Setup OAuth token endpoint to fail
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(401)
+            .withBody("Invalid client credentials")
+        )
+    )
+
+    // Create OAuth config with invalid credentials
+    val oauthConfig = OAuthConfig(
+      tokenUrl = "http://localhost:${wireMockServer.port()}/oauth/token",
+      clientId = "invalid-client-id",
+      clientSecret = "invalid-client-secret",
+      scopes = "fern.write"
+    )
+
+    // Test API call with invalid OAuth
+    val result = sendTestRun(
+      testRun,
+      "http://localhost:${wireMockServer.port()}",
+      verbose = true,
+      oauthConfig = oauthConfig
+    )
+
+    // Verify failure
+    assertTrue(result.isFailure)
+    val exception = result.exceptionOrNull()
+    assertTrue(exception?.message?.contains("Failed to add OAuth authentication") ?: false)
+  }
+
+  @Test
+  fun `sendTestRun should retry OAuth token on authentication failure`() {
+    // Setup OAuth token endpoint
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "retry-token",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    // Setup test data endpoint to fail first, then succeed
+    stubFor(
+      post(urlEqualTo("/api/v1/test-runs"))
+        .inScenario("Retry Scenario")
+        .whenScenarioStateIs("Started")
+        .willReturn(
+          aResponse()
+            .withStatus(401)
+            .withBody("{\"error\":\"Unauthorized\"}")
+        )
+        .willSetStateTo("First Attempt")
+    )
+
+    stubFor(
+      post(urlEqualTo("/api/v1/test-runs"))
+        .inScenario("Retry Scenario")
+        .whenScenarioStateIs("First Attempt")
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody("{\"status\":\"success\"}")
+        )
+    )
+
+    // Create OAuth config
+    val oauthConfig = OAuthConfig(
+      tokenUrl = "http://localhost:${wireMockServer.port()}/oauth/token",
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret",
+      scopes = "fern.write"
+    )
+
+    // Test API call with OAuth
+    val result = sendTestRun(
+      testRun,
+      "http://localhost:${wireMockServer.port()}",
+      verbose = true,
+      oauthConfig = oauthConfig
+    )
+
+    // Verify success after retry
+    assertTrue(result.isSuccess)
+
+    // Verify multiple attempts were made (more than 1)
+    verify(
+      moreThan(1),
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
+    )
+  }
+
+  @Test
+  fun `sendTestRun should include Authorization header when following redirects`() {
+    // Setup OAuth token endpoint
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "redirect-token-789",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    // Setup redirect
+    stubFor(
+      post(urlEqualTo("/api/v1/test-runs"))
+        .willReturn(
+          aResponse()
+            .withStatus(307)
+            .withHeader("Location", "/api/v1/test-runs/redirect")
+        )
+    )
+
+    // Setup redirected endpoint
+    stubFor(
+      post(urlEqualTo("/api/v1/test-runs/redirect"))
+        .withHeader("Authorization", equalTo("Bearer redirect-token-789"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody("{\"status\":\"success\"}")
+        )
+    )
+
+    // Create OAuth config
+    val oauthConfig = OAuthConfig(
+      tokenUrl = "http://localhost:${wireMockServer.port()}/oauth/token",
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret"
+    )
+
+    // Test API call with OAuth and redirect
+    val result = sendTestRun(
+      testRun,
+      "http://localhost:${wireMockServer.port()}",
+      verbose = true,
+      oauthConfig = oauthConfig
+    )
+
+    // Verify success
+    assertTrue(result.isSuccess)
+
+    // Verify both requests included Authorization header
+    verify(
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
+        .withHeader("Authorization", equalTo("Bearer redirect-token-789"))
+    )
+    verify(
+      postRequestedFor(urlEqualTo("/api/v1/test-runs/redirect"))
+        .withHeader("Authorization", equalTo("Bearer redirect-token-789"))
+    )
+  }
+
+  @Test
+  fun `sendTestRun should use custom API endpoint path with OAuth`() {
+    // Setup OAuth token endpoint
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "custom-path-token",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    // Setup custom endpoint
+    stubFor(
+      post(urlEqualTo("/custom/api/path"))
+        .withHeader("Authorization", equalTo("Bearer custom-path-token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody("{\"status\":\"success\"}")
+        )
+    )
+
+    // Create OAuth config
+    val oauthConfig = OAuthConfig(
+      tokenUrl = "http://localhost:${wireMockServer.port()}/oauth/token",
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret"
+    )
+
+    // Test API call with OAuth and custom endpoint
+    val result = sendTestRun(
+      testRun,
+      "http://localhost:${wireMockServer.port()}",
+      verbose = true,
+      oauthConfig = oauthConfig,
+      apiEndpointPath = "custom/api/path"
+    )
+
+    // Verify success
+    assertTrue(result.isSuccess)
+
+    // Verify request was sent to custom endpoint with auth
+    verify(
+      postRequestedFor(urlEqualTo("/custom/api/path"))
+        .withHeader("Authorization", equalTo("Bearer custom-path-token"))
+    )
   }
 }

--- a/src/test/kotlin/DataSenderTest.kt
+++ b/src/test/kotlin/DataSenderTest.kt
@@ -46,7 +46,7 @@ class DataSenderTest {
   fun `sendTestRun should successfully send data`() {
     // Setup mock server
     stubFor(
-      post(urlEqualTo("/api/testrun/"))
+      post(urlEqualTo("/api/v1/test-runs"))
         .withHeader("Content-Type", equalTo("application/json"))
         .willReturn(
           aResponse()
@@ -61,7 +61,7 @@ class DataSenderTest {
     // Verify
     assertTrue(result.isSuccess)
     verify(
-      postRequestedFor(urlEqualTo("/api/testrun/"))
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
         .withHeader("Content-Type", equalTo("application/json"))
     )
   }
@@ -70,17 +70,17 @@ class DataSenderTest {
    fun `sendTestRun should follow redirects`() {
      // Setup mock server for initial redirect
      stubFor(
-       post(urlEqualTo("/api/testrun/"))
+       post(urlEqualTo("/api/v1/test-runs"))
          .willReturn(
            aResponse()
              .withStatus(307)
-             .withHeader("Location", "/api/testrun/redirect")
+             .withHeader("Location", "/api/v1/test-runs/redirect")
          )
      )
 
      // Setup mock server for the redirected endpoint
      stubFor(
-       post(urlEqualTo("/api/testrun/redirect"))
+       post(urlEqualTo("/api/v1/test-runs/redirect"))
          .withHeader("Content-Type", equalTo("application/json"))
          .willReturn(
            aResponse()
@@ -95,11 +95,11 @@ class DataSenderTest {
      // Verify
      assertTrue(result.isSuccess)
      verify(
-       postRequestedFor(urlEqualTo("/api/testrun/"))
+       postRequestedFor(urlEqualTo("/api/v1/test-runs"))
          .withHeader("Content-Type", equalTo("application/json"))
      )
      verify(
-       postRequestedFor(urlEqualTo("/api/testrun/redirect"))
+       postRequestedFor(urlEqualTo("/api/v1/test-runs/redirect"))
          .withHeader("Content-Type", equalTo("application/json"))
      )
    }
@@ -108,7 +108,7 @@ class DataSenderTest {
   fun `sendTestRun should handle server errors`() {
     // Setup mock server to return error
     stubFor(
-      post(urlEqualTo("/api/testrun/"))
+      post(urlEqualTo("/api/v1/test-runs"))
         .willReturn(
           aResponse()
             .withStatus(500)

--- a/src/test/kotlin/FernPublisherPluginTest.kt
+++ b/src/test/kotlin/FernPublisherPluginTest.kt
@@ -39,7 +39,7 @@ class FernPublisherPluginTest {
 
     // Stub the API endpoint
     stubFor(
-      post(urlEqualTo("/api/testrun/"))
+      post(urlEqualTo("/api/v1/test-runs"))
         .willReturn(aResponse().withStatus(200))
     )
 
@@ -118,7 +118,7 @@ class FernPublisherPluginTest {
 
     // Verify the API was called
     verify(
-      postRequestedFor(urlEqualTo("/api/testrun/"))
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
         .withHeader("Content-Type", equalTo("application/json"))
     )
   }
@@ -128,7 +128,7 @@ class FernPublisherPluginTest {
     // Reset stub to return an error
     reset()
     stubFor(
-      post(urlEqualTo("/api/testrun/"))
+      post(urlEqualTo("/api/v1/test-runs"))
         .willReturn(aResponse().withStatus(500))
     )
 
@@ -305,7 +305,7 @@ class FernPublisherPluginTest {
 
     // Verify the API was called
     verify(
-      postRequestedFor(urlEqualTo("/api/testrun/"))
+      postRequestedFor(urlEqualTo("/api/v1/test-runs"))
         .withHeader("Content-Type", equalTo("application/json"))
     )
   }

--- a/src/test/kotlin/OAuthClientTest.kt
+++ b/src/test/kotlin/OAuthClientTest.kt
@@ -1,0 +1,377 @@
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import io.github.guidewire.oss.auth.OAuthClient
+import io.github.guidewire.oss.auth.OAuthConfig
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
+import uk.org.webcompere.systemstubs.jupiter.SystemStub
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.http.HttpRequest
+import java.net.URI
+
+@ExtendWith(SystemStubsExtension::class)
+
+class OAuthClientTest {
+
+  private lateinit var wireMockServer: WireMockServer
+  private lateinit var tokenUrl: String
+
+  @BeforeEach
+  fun setup() {
+    wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
+    wireMockServer.start()
+    configureFor("localhost", wireMockServer.port())
+    tokenUrl = "http://localhost:${wireMockServer.port()}/oauth/token"
+  }
+
+  @AfterEach
+  fun tearDown() {
+    wireMockServer.stop()
+  }
+
+  @Test
+  fun `fromConfig should create client with valid config`() {
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret",
+      scopes = "fern.write"
+    )
+
+    val client = OAuthClient.fromConfig(config)
+
+    assertNotNull(client)
+  }
+
+  @Test
+  fun `fromEnvironment should return null when AUTH_URL not set`() {
+    val client = OAuthClient.fromEnvironment()
+
+    assertNull(client)
+  }
+
+  @Test
+  fun `fromEnvironment should create client with valid environment variables`() {
+    EnvironmentVariables(
+      "AUTH_URL", tokenUrl,
+      "FERN_AUTH_CLIENT_ID", "test-client-id",
+      "FERN_AUTH_CLIENT_SECRET", "test-client-secret",
+      "FERN_CLIENT_SCOPE", "fern.write"
+    ).execute {
+      val client = OAuthClient.fromEnvironment()
+      assertNotNull(client)
+    }
+  }
+
+  @Test
+  fun `fromEnvironment should throw exception when AUTH_URL is set but clientId is missing`() {
+    EnvironmentVariables(
+      "AUTH_URL", tokenUrl,
+      "FERN_AUTH_CLIENT_SECRET", "test-client-secret"
+    ).execute {
+      val exception = assertThrows(IllegalStateException::class.java) {
+        OAuthClient.fromEnvironment()
+      }
+      assertTrue(exception.message?.contains("FERN_AUTH_CLIENT_ID") ?: false)
+    }
+  }
+
+  @Test
+  fun `fromEnvironment should throw exception when AUTH_URL is set but clientSecret is missing`() {
+    EnvironmentVariables(
+      "AUTH_URL", tokenUrl,
+      "FERN_AUTH_CLIENT_ID", "test-client-id"
+    ).execute {
+      val exception = assertThrows(IllegalStateException::class.java) {
+        OAuthClient.fromEnvironment()
+      }
+      assertTrue(exception.message?.contains("FERN_AUTH_CLIENT_SECRET") ?: false)
+    }
+  }
+
+  @Test
+  fun `getToken should fetch token on first call`() {
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "test-access-token-123",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "fern.write"
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret",
+      scopes = "fern.write"
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    val token = client.getToken()
+
+    assertEquals("test-access-token-123", token)
+    verify(
+      postRequestedFor(urlEqualTo("/oauth/token"))
+        .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+        .withRequestBody(containing("client_id=test-client-id"))
+        .withRequestBody(containing("client_secret=test-client-secret"))
+        .withRequestBody(containing("scope=fern.write"))
+    )
+  }
+
+  @Test
+  fun `getToken should return cached token if not expired`() {
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "cached-token",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret"
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    // First call - should fetch token
+    val token1 = client.getToken()
+    // Second call - should use cached token
+    val token2 = client.getToken()
+
+    assertEquals(token1, token2)
+    assertEquals("cached-token", token2)
+    // Verify only one call was made to the token endpoint
+    verify(1, postRequestedFor(urlEqualTo("/oauth/token")))
+  }
+
+  @Test
+  fun `fetchToken should throw exception on non-200 response`() {
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(401)
+            .withBody("Invalid client credentials")
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "invalid-client-id",
+      clientSecret = "invalid-client-secret"
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    val exception = assertThrows(RuntimeException::class.java) {
+      client.getToken()
+    }
+
+    assertTrue(exception.message?.contains("401") ?: false)
+    assertTrue(exception.message?.contains("Failed to fetch OAuth token") ?: false)
+  }
+
+  @Test
+  fun `addAuthHeader should add Bearer token to request`() {
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "bearer-token-456",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret"
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    val requestBuilder = HttpRequest.newBuilder()
+      .uri(URI("http://example.com/api"))
+      .POST(HttpRequest.BodyPublishers.noBody())
+
+    client.addAuthHeader(requestBuilder)
+    val request = requestBuilder.build()
+
+    val authHeader = request.headers().firstValue("Authorization").orElse(null)
+    assertNotNull(authHeader)
+    assertEquals("Bearer bearer-token-456", authHeader)
+  }
+
+  @Test
+  fun `token request should include all required parameters`() {
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "test-token",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "my-client",
+      clientSecret = "my-secret",
+      scopes = "fern.write fernproject.myproject"
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    client.getToken()
+
+    verify(
+      postRequestedFor(urlEqualTo("/oauth/token"))
+        .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+        .withRequestBody(containing("client_id=my-client"))
+        .withRequestBody(containing("client_secret=my-secret"))
+        .withRequestBody(containing("scope=fern.write+fernproject.myproject"))
+    )
+  }
+
+  @Test
+  fun `token request should not include scope parameter when scopes are empty`() {
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "test-token",
+                "token_type": "Bearer",
+                "expires_in": 3600
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "my-client",
+      clientSecret = "my-secret",
+      scopes = ""
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    client.getToken()
+
+    verify(
+      postRequestedFor(urlEqualTo("/oauth/token"))
+        .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+        .withRequestBody(containing("client_id=my-client"))
+        .withRequestBody(containing("client_secret=my-secret"))
+        .withRequestBody(notMatching(".*scope=.*"))
+    )
+  }
+
+  @Test
+  fun `fromEnvironment should handle missing scope variable gracefully`() {
+    EnvironmentVariables(
+      "AUTH_URL", tokenUrl,
+      "FERN_AUTH_CLIENT_ID", "test-client-id",
+      "FERN_AUTH_CLIENT_SECRET", "test-client-secret"
+    ).execute {
+      val client = OAuthClient.fromEnvironment()
+      assertNotNull(client)
+    }
+  }
+
+  @Test
+  fun `getToken should handle token expiry correctly`() {
+    var callCount = 0
+    stubFor(
+      post(urlEqualTo("/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "access_token": "short-lived-token-${++callCount}",
+                "token_type": "Bearer",
+                "expires_in": 1
+              }
+              """.trimIndent()
+            )
+        )
+    )
+
+    val config = OAuthConfig(
+      tokenUrl = tokenUrl,
+      clientId = "test-client-id",
+      clientSecret = "test-client-secret"
+    )
+    val client = OAuthClient.fromConfig(config)
+
+    // First call
+    val token1 = client.getToken()
+    assertNotNull(token1)
+
+    // Wait for token to expire (1 second + 30 second buffer means it expires immediately in practice)
+    Thread.sleep(100)
+
+    // Second call should fetch a new token because the first one is expired
+    val token2 = client.getToken()
+    assertNotNull(token2)
+
+    // Both calls should have been made since the token has a very short expiry
+    verify(moreThan(0), postRequestedFor(urlEqualTo("/oauth/token")))
+  }
+}

--- a/src/test/kotlin/OAuthClientTest.kt
+++ b/src/test/kotlin/OAuthClientTest.kt
@@ -50,7 +50,7 @@ class OAuthClientTest {
 
   @Test
   fun `fromEnvironment should return null when AUTH_URL not set`() {
-    EnvironmentVariables().clear("AUTH_URL").execute {
+    EnvironmentVariables().execute {
       val client = OAuthClient.fromEnvironment()
       assertNull(client)
     }
@@ -347,7 +347,7 @@ class OAuthClientTest {
               {
                 "access_token": "short-lived-token-${++callCount}",
                 "token_type": "Bearer",
-                "expires_in": 1
+                "expires_in": 0
               }
               """.trimIndent()
             )
@@ -365,14 +365,14 @@ class OAuthClientTest {
     val token1 = client.getToken()
     assertNotNull(token1)
 
-    // Wait for token to expire (1 second + 30 second buffer means it expires immediately in practice)
-    Thread.sleep(100)
+    // Wait for token to expire (0 seconds + 30 second buffer = 30 seconds)
+    Thread.sleep(31000)
 
     // Second call should fetch a new token because the first one is expired
     val token2 = client.getToken()
     assertNotNull(token2)
 
-     // Token should be fetched twice because expiry is immediate
+     // Token should be fetched twice because expiry time has passed
     verify(2, postRequestedFor(urlEqualTo("/oauth/token")))
   }
 }

--- a/src/test/kotlin/OAuthClientTest.kt
+++ b/src/test/kotlin/OAuthClientTest.kt
@@ -50,9 +50,10 @@ class OAuthClientTest {
 
   @Test
   fun `fromEnvironment should return null when AUTH_URL not set`() {
-    val client = OAuthClient.fromEnvironment()
-
-    assertNull(client)
+    EnvironmentVariables().clear("AUTH_URL").execute {
+      val client = OAuthClient.fromEnvironment()
+      assertNull(client)
+    }
   }
 
   @Test
@@ -371,7 +372,7 @@ class OAuthClientTest {
     val token2 = client.getToken()
     assertNotNull(token2)
 
-    // Both calls should have been made since the token has a very short expiry
-    verify(moreThan(0), postRequestedFor(urlEqualTo("/oauth/token")))
+     // Token should be fetched twice because expiry is immediate
+    verify(2, postRequestedFor(urlEqualTo("/oauth/token")))
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds OAuth 2.0 client-credentials auth, a configurable API path (default api/v1/test-runs), and safer 307 redirect handling for publishing to Fern. Enables authenticated publishing and aligns with Linear #19.

- **New Features**
  - OAuth client-credentials with token caching/auto-refresh; configure via CLI/Gradle or environment; auto-detects from env when set.
  - Authorization header added and preserved across 307 redirects; redirects are bounded (max 5) and restricted to the same scheme/host.
  - Custom API endpoint path; default is api/v1/test-runs (CLI: --api-endpoint-path, Gradle: apiEndpointPath, env: FERN_API_ENDPOINT_PATH).
  - Docs expanded (auth env vars, local Maven publish, native CLI build, testing) and tests added for OAuth, redirects, and endpoint configuration; default version is 1.1.0.

- **Migration**
  - If you previously used /api/testrun/, set apiEndpointPath (or FERN_API_ENDPOINT_PATH) to keep the old path.

<sup>Written for commit da88b61176569f2bbdf9977797199708680f18cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-junit-gradle-plugin/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

